### PR TITLE
fix(hermes-agent): handle analyzer timeouts on Windows

### DIFF
--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -120,6 +120,10 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
     )
 
     try:
+        if os.name == "nt":
+            launch_options = {}
+        else:
+            launch_options = {"start_new_session": True}
         process = subprocess.Popen(
             [executable] + ANALYZER[1:],
             stdin=subprocess.PIPE,
@@ -136,8 +140,9 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
             # still the real Hermes working directory, which the analysis needs.
             cwd=os.path.expanduser("~"),
             # Own process group so the timeout below can kill the whole tree: npx's descendants
-            # outlive a kill aimed at npx alone and keep holding the pipes captured here.
-            start_new_session=True,
+            # outlive a kill aimed at npx alone and keep holding the pipes captured here. Windows
+            # uses taskkill's process-tree traversal instead because sessions are POSIX-only.
+            **launch_options,
         )
     except OSError as error:
         return _block("analysis could not start (%s)." % error)
@@ -146,12 +151,22 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
         stdout, _ = process.communicate(payload, timeout=TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
         try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except OSError:
+            if os.name == "nt":
+                subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=1,
+                    check=False,
+                )
+            else:
+                os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, subprocess.SubprocessError):
             pass
         try:
-            process.communicate(timeout=TIMEOUT_SECONDS)
-        except subprocess.TimeoutExpired:
+            process.communicate(timeout=1)
+        except (OSError, subprocess.SubprocessError):
             pass
         return _block("analysis timed out after %ss." % TIMEOUT_SECONDS)
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -152,8 +152,17 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
     except subprocess.TimeoutExpired:
         try:
             if os.name == "nt":
+                system_root = os.environ.get("SystemRoot")
+                if not system_root:
+                    raise OSError("SystemRoot is unavailable")
                 subprocess.run(
-                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    [
+                        os.path.join(system_root, "System32", "taskkill.exe"),
+                        "/PID",
+                        str(process.pid),
+                        "/T",
+                        "/F",
+                    ],
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,

--- a/src/integrations/hermes-agent/artifact.ts
+++ b/src/integrations/hermes-agent/artifact.ts
@@ -151,8 +151,17 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
     except subprocess.TimeoutExpired:
         try:
             if os.name == "nt":
+                system_root = os.environ.get("SystemRoot")
+                if not system_root:
+                    raise OSError("SystemRoot is unavailable")
                 subprocess.run(
-                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    [
+                        os.path.join(system_root, "System32", "taskkill.exe"),
+                        "/PID",
+                        str(process.pid),
+                        "/T",
+                        "/F",
+                    ],
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,

--- a/src/integrations/hermes-agent/artifact.ts
+++ b/src/integrations/hermes-agent/artifact.ts
@@ -119,6 +119,10 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
     )
 
     try:
+        if os.name == "nt":
+            launch_options = {}
+        else:
+            launch_options = {"start_new_session": True}
         process = subprocess.Popen(
             [executable] + ANALYZER[1:],
             stdin=subprocess.PIPE,
@@ -135,8 +139,9 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
             # still the real Hermes working directory, which the analysis needs.
             cwd=os.path.expanduser("~"),
             # Own process group so the timeout below can kill the whole tree: npx's descendants
-            # outlive a kill aimed at npx alone and keep holding the pipes captured here.
-            start_new_session=True,
+            # outlive a kill aimed at npx alone and keep holding the pipes captured here. Windows
+            # uses taskkill's process-tree traversal instead because sessions are POSIX-only.
+            **launch_options,
         )
     except OSError as error:
         return _block("analysis could not start (%s)." % error)
@@ -145,12 +150,22 @@ def _pre_tool_call(tool_name="", args=None, session_id="", task_id="", **_):
         stdout, _ = process.communicate(payload, timeout=TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
         try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except OSError:
+            if os.name == "nt":
+                subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=1,
+                    check=False,
+                )
+            else:
+                os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, subprocess.SubprocessError):
             pass
         try:
-            process.communicate(timeout=TIMEOUT_SECONDS)
-        except subprocess.TimeoutExpired:
+            process.communicate(timeout=1)
+        except (OSError, subprocess.SubprocessError):
             pass
         return _block("analysis timed out after %ss." % TIMEOUT_SECONDS)
 

--- a/tests/integrations/hermes-agent/install.test.ts
+++ b/tests/integrations/hermes-agent/install.test.ts
@@ -131,11 +131,10 @@ async function runHermesCli(
   };
 }
 
-const pythonBin = Bun.which('python3') ?? Bun.which('python');
-
-function hasPython3() {
-  return pythonBin !== null && Bun.spawnSync([pythonBin, '--version']).exitCode === 0;
-}
+const pythonBin = ['python3', 'python']
+  .map((name) => Bun.which(name))
+  .filter((path): path is string => path !== null)
+  .find((path) => Bun.spawnSync([path, '--version']).exitCode === 0);
 
 /** The `task_id` the host passes; Hermes keys its cwd record by it when the contextvar is unset. */
 const HERMES_TASK_ID = 'task-1';
@@ -355,7 +354,7 @@ describe('Hermes Agent plugin artifact', () => {
         ?.content ?? '';
 
     expect(source).toContain('{"start_new_session": True}');
-    expect(source).toContain('["taskkill", "/PID", str(process.pid), "/T", "/F"]');
+    expect(source).toContain('os.path.join(system_root, "System32", "taskkill.exe")');
   });
 
   // Decoding with the process locale raises UnicodeDecodeError on undecodable analyzer output,
@@ -372,7 +371,7 @@ describe('Hermes Agent plugin artifact', () => {
   // Exercises the generated Python through Hermes' own contract: register(ctx) ->
   // ctx.register_hook('pre_tool_call', cb), then cb(tool_name=, args=, session_id=).
   // A stub stands in for the adapter so each transport outcome can be forced.
-  describe.skipIf(!hasPython3())('module behaviour under Hermes', () => {
+  describe.skipIf(pythonBin === undefined)('module behaviour under Hermes', () => {
     beforeAll(() => {
       analyzerStubBinDir = writeAnalyzerStub();
     });

--- a/tests/integrations/hermes-agent/install.test.ts
+++ b/tests/integrations/hermes-agent/install.test.ts
@@ -131,8 +131,10 @@ async function runHermesCli(
   };
 }
 
+const pythonBin = Bun.which('python3') ?? Bun.which('python');
+
 function hasPython3() {
-  return Bun.spawnSync(['python3', '--version']).exitCode === 0;
+  return pythonBin !== null && Bun.spawnSync([pythonBin, '--version']).exitCode === 0;
 }
 
 /** The `task_id` the host passes; Hermes keys its cwd record by it when the contextvar is unset. */
@@ -145,6 +147,34 @@ spec = importlib.util.spec_from_file_location("ccsn", sys.argv[4])
 plugin = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(plugin)
 plugin.TIMEOUT_SECONDS = 1
+if mode == "start-fail":
+    def fail_start(*_, **__):
+        raise OSError("synthetic start failure")
+    plugin.subprocess.Popen = fail_start
+if mode == "cleanup-fail":
+    class TimedOutProcess:
+        pid = 1
+        def communicate(self, *_, **kwargs):
+            raise plugin.subprocess.TimeoutExpired("npx", kwargs.get("timeout"))
+    def fail_cleanup(*_, **__):
+        raise OSError("synthetic cleanup failure")
+    plugin.subprocess.Popen = lambda *_, **__: TimedOutProcess()
+    if os.name == "nt":
+        plugin.subprocess.run = fail_cleanup
+    else:
+        plugin.os.killpg = fail_cleanup
+if mode == "native-hang":
+    plugin.ANALYZER = [sys.executable, "-c", """
+import os
+import subprocess
+import sys
+import time
+
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(20)"])
+with open(os.environ["CC_SAFETY_NET_TEST_GRANDCHILD_PID"], "w", encoding="utf-8") as pid_file:
+    pid_file.write(str(child.pid))
+time.sleep(20)
+"""]
 registered = {}
 class Ctx:
     def register_hook(self, name, callback):
@@ -245,15 +275,7 @@ function runPluginCallback(
 
     // `missing` runs with an empty PATH, so Python itself is launched by absolute path.
     const spawned = Bun.spawnSync(
-      [
-        Bun.which('python3') ?? 'python3',
-        '-c',
-        PYTHON_HOST,
-        mode,
-        tool,
-        JSON.stringify(args),
-        modulePath,
-      ],
+      [pythonBin ?? 'python3', '-c', PYTHON_HOST, mode, tool, JSON.stringify(args), modulePath],
       {
         cwd: dir,
         env: {
@@ -327,6 +349,15 @@ describe('Hermes Agent plugin artifact', () => {
     expect(source).toContain('"cc-safety-net", "hook", "--hermes-agent"');
   });
 
+  test('module uses platform-specific analyzer launch and process-tree cleanup', () => {
+    const source =
+      buildHermesAgentPluginFiles(getPackageVersion()).find((file) => file.name === MODULE_FILE)
+        ?.content ?? '';
+
+    expect(source).toContain('{"start_new_session": True}');
+    expect(source).toContain('["taskkill", "/PID", str(process.pid), "/T", "/F"]');
+  });
+
   // Decoding with the process locale raises UnicodeDecodeError on undecodable analyzer output,
   // and Hermes turns a raising callback into an allowed tool call.
   test('decodes the analyzer output with a decoder that cannot raise', () => {
@@ -360,6 +391,11 @@ describe('Hermes Agent plugin artifact', () => {
       ['fail', 'CC Safety Net failed closed: analysis exited with status 3.'],
       ['allow-shaped', 'CC Safety Net failed closed: analysis returned an unexpected directive.'],
       ['missing', 'CC Safety Net failed closed: npx was not found on PATH.'],
+      [
+        'start-fail',
+        'CC Safety Net failed closed: analysis could not start (synthetic start failure).',
+      ],
+      ['cleanup-fail', 'CC Safety Net failed closed: analysis timed out after 1s.'],
     ] as const)('%s', (mode, expected) => {
       const run = runPluginCallback(mode, 'terminal', { command: 'rm -rf /' });
       expect(run.result).toEqual(
@@ -437,6 +473,21 @@ describe('Hermes Agent plugin artifact', () => {
       expect(run.grandchildPid).toBeGreaterThan(0);
       expect(isRunning(run.grandchildPid)).toBe(false);
     });
+
+    test.skipIf(process.platform !== 'win32')(
+      '[windows] kills the native analyzer process tree and returns a timeout block',
+      () => {
+        const run = runPluginCallback('native-hang', 'terminal', { command: 'ls' });
+
+        expect(run.result).toEqual({
+          action: 'block',
+          message: 'CC Safety Net failed closed: analysis timed out after 1s.',
+        });
+        expect(run.elapsedSeconds).toBeLessThan(3);
+        expect(run.grandchildPid).toBeGreaterThan(0);
+        expect(isRunning(run.grandchildPid)).toBe(false);
+      },
+    );
 
     // Hermes' own first-command behaviour: no record yet, so the command runs in the process cwd.
     // A repository-local node_modules/.bin/cc-safety-net would otherwise win the `npx` lookup


### PR DESCRIPTION
## Root cause

The generated Hermes Agent Python plugin always passed `start_new_session=True` and timed out with `os.killpg(..., SIGKILL)`. Both are POSIX process controls. On native Windows, `Popen` rejects `start_new_session` with `ValueError`, which escaped the callback instead of returning Hermes' required fail-closed block. Killing only `npx` is not enough because descendants can keep the captured pipes open.

## Change

- Keep the existing POSIX session and process-group cleanup.
- On Windows, omit the POSIX launch option and terminate the analyzer tree with `%SystemRoot%\System32\taskkill.exe /PID <pid> /T /F`, passed as an argument array without a shell.
- Bound and absorb cleanup failures so startup errors and timeouts still return an explicit block.
- Add generated-artifact and behavior coverage for startup and cleanup failures, preserve the POSIX descendant test, and add a native `[windows]` test that verifies the timeout response and descendant termination with real Python processes.

## Verification

- `bun test tests/integrations/hermes-agent/install.test.ts`: 55 passed, 1 Windows-only skip, 0 failed
- `bun run check`: 5,095 passed, 36 platform skips, 0 failed; coverage verified
- Native `Windows Tests / test-windows`: 32 passed, 16 unrelated platform skips, 0 failed; 104 assertions across 48 selected tests, including the real `[windows]` timeout/process-tree path
- Packed runtimes passed on Windows Node 24, macOS Node 24, and Ubuntu Node 18/20/22/24; Codecov project and patch checks passed

## Residual risk

Windows `taskkill /T` can terminate the live `npx` launcher and its active descendants, which is the supported and natively tested timeout path. If the launcher has already exited and orphaned a descendant before the timeout, `taskkill` cannot reconstruct that former process tree. Covering that case would require the Job Object/process-tracking framework intentionally excluded from this scoped fix.

Base commit: `7f12dc30` (merged PR #102).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess timeout handling across Windows and POSIX systems.
  * Ensured timed-out processes and their child processes are terminated more reliably.
  * Improved cleanup behavior when subprocess startup or shutdown encounters errors.
  * Improved Windows compatibility when locating and invoking process termination tools.

* **Tests**
  * Expanded coverage for startup failures, cleanup failures, platform-specific process handling, Python executable selection, and Windows process-tree timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
