### PR TITLE
test(install): make fake commands portable

### DIFF
--- a/tests/cli/install/orchestration.test.ts
+++ b/tests/cli/install/orchestration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough, Writable } from 'node:stream';
 import { runInstallCommand } from '@/cli/install';
@@ -43,7 +43,7 @@ async function installOverSettings(
   settings: string,
 ) {
   const homeDir = makeTempHome(name);
-  const path = makeFakeBin(homeDir, { [binary]: 'exit 0' });
+  const path = makeFakeBin(homeDir, { [binary]: '' });
   const settingsPath = join(homeDir, settingsRelativePath);
   mkdirSync(dirname(settingsPath), { recursive: true });
   writeFileSync(settingsPath, settings);
@@ -65,7 +65,7 @@ async function probeInstallChoices(
   setup(homeDir);
   const path = makeFakeBin(
     homeDir,
-    Object.fromEntries(PROBED_CLIS.map((command) => [command, fixtures[command] ?? 'exit 0'])),
+    Object.fromEntries(PROBED_CLIS.map((command) => [command, fixtures[command] ?? ''])),
   );
   const choices: InstallTargetChoice[] = [];
 
@@ -255,7 +255,7 @@ describe('flagged install loading state', () => {
   // the spinner delay timer, an ordering no injected sleep can pin down.
   test('prints the install message after a flagged install runs', async () => {
     const homeDir = makeTempHome('safety-net-install-spinner');
-    const path = makeFakeBin(homeDir, { pi: 'exit 0' });
+    const path = makeFakeBin(homeDir, { pi: '' });
     const { chunks, output } = createLolcatOutput();
 
     const exitCode = await withEnv({ HOME: homeDir, PATH: path }, () =>
@@ -312,32 +312,27 @@ describe('interactive uninstall detection', () => {
  */
 function makeAmpFakeBin(homeDir: string, seedCheckout: boolean) {
   return makeFakeBin(homeDir, {
-    amp: [
-      'case "$1 $2" in',
-      `  "plugins repositories") printf '%s\\n' '[{"scope":"user","exists":true,"viewerCanWrite":true,"cloneRef":"tester/-/plugins"}]' ;;`,
-      seedCheckout
-        ? `  "clone user-plugins") mkdir -p "$3/cc-safety-net"; printf '%s\\n' '${AMP_MANAGED_HEADER}' > "$3/cc-safety-net/index.ts" ;;`
-        : '  "clone user-plugins") : ;;',
-      'esac',
-    ].join('\n'),
-    git: [
-      'printf \'%s\\n\' "$*" >> "$HOME/git.log"',
-      'case "$1 $2" in',
-      // An empty porcelain status means "nothing staged", which skips the commit and push.
-      '  "status --porcelain") printf \'%s\\n\' "M  cc-safety-net/index.ts" ;;',
-      'esac',
-    ].join('\n'),
+    amp: `if (args[0] === 'plugins' && args[1] === 'repositories') {
+  console.log('[{"scope":"user","exists":true,"viewerCanWrite":true,"cloneRef":"tester/-/plugins"}]');
+}
+if (args[0] === 'clone' && args[1] === 'user-plugins' && ${seedCheckout}) {
+  const pluginDir = join(args[2] ?? '', 'cc-safety-net');
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(join(pluginDir, 'index.ts'), ${JSON.stringify(AMP_MANAGED_HEADER)} + '\\n');
+}`,
+    git: `appendFileSync(join(process.env.HOME ?? '', 'git.log'), commandLine + '\\n');
+// An empty porcelain status means "nothing staged", which skips the commit and push.
+if (commandLine === 'status --porcelain') console.log('M  cc-safety-net/index.ts');`,
   });
 }
 
 /**
- * A PATH holding nothing but a `bun` symlink, so the CLI under test starts while no real `amp`
- * can ever be resolved — the missing-CLI path must not reach the account's hosted repository.
+ * An empty PATH, so no real `amp` can be resolved and the missing-CLI path cannot reach the
+ * account's hosted repository. The CLI under test starts through the current Bun executable.
  */
-function makeBunOnlyPath(homeDir: string) {
+function makeEmptyPath(homeDir: string) {
   const binDir = join(homeDir, 'runtime-bin');
   mkdirSync(binDir, { recursive: true });
-  symlinkSync(process.execPath, join(binDir, 'bun'));
   return binDir;
 }
 
@@ -378,7 +373,7 @@ describe('Amp personal-scope install command', () => {
 
     const result = await runCli(['install', '--amp'], '', {
       HOME: homeDir,
-      PATH: makeBunOnlyPath(homeDir),
+      PATH: makeEmptyPath(homeDir),
     });
 
     expect(result.exitCode).toBe(1);

--- a/tests/cli/install/tui.test.ts
+++ b/tests/cli/install/tui.test.ts
@@ -68,7 +68,7 @@ type CapturedChoice = {
 };
 
 async function spawnInstallEval<T>(script: string, env: Record<string, string | undefined>) {
-  const proc = Bun.spawn(['bun', '--eval', script], {
+  const proc = Bun.spawn([process.execPath, '--eval', script], {
     cwd: process.cwd(),
     env: { ...process.env, ...env },
     stderr: 'pipe',

--- a/tests/cli/install/update.test.ts
+++ b/tests/cli/install/update.test.ts
@@ -11,6 +11,7 @@ import {
   makeLoggedFakeCommandHome,
   writeClaudePluginRecords,
   writeFakeCommands,
+  writeLoggedFakeCommand,
 } from '../../integrations/install/install-test-helpers';
 import { createLolcatOutput, stripAnsi } from '../lolcat-test-helpers';
 
@@ -49,7 +50,7 @@ function normalizedCommandLog(logPath: string): string[] {
     .trim()
     .split('\n')
     .filter(Boolean)
-    .map((entry) => entry.replace(/^.*\/bin\//, ''));
+    .map((entry) => entry.replace(/^.*[\\/]bin[\\/]/, ''));
 }
 
 async function expectUpdateFindsNothing(homeDir: string, cwd?: string) {
@@ -281,14 +282,12 @@ describe('update command', () => {
 
   test('migrates a legacy-only Codex integration', async () => {
     const fake = makeFakeBinHome('safety-net-update-legacy-codex', ['codex']);
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'codex'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled\n'
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'codex',
+      `if (commandLine === 'plugin list') {
+  console.log('safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled');
+}`,
     );
 
     await expectCodexLegacyMigration(fake);
@@ -300,14 +299,12 @@ fi
       join(fake.homeDir, '.copilot', 'installed-plugins', '_direct', 'copilot-safety-net'),
       { recursive: true },
     );
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'copilot'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\n  copilot-safety-net (v1.0.0)\n'
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'copilot',
+      `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify('Installed plugins:\n  copilot-safety-net (v1.0.0)')});
+}`,
     );
 
     try {
@@ -334,17 +331,15 @@ fi
     mkdirSync(join(fake.homeDir, '.copilot', 'installed-plugins', 'cc-marketplace', 'safety-net'), {
       recursive: true,
     });
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'copilot'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\n  • safety-net@cc-marketplace (v1.0.6)\n'
-fi
-if [ "$*" = "plugin marketplace list" ]; then
-  printf 'Registered marketplaces:\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)\n'
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'copilot',
+      `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify('Installed plugins:\n  • safety-net@cc-marketplace (v1.0.6)')});
+}
+if (commandLine === 'plugin marketplace list') {
+  console.log(${JSON.stringify('Registered marketplaces:\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)')});
+}`,
     );
 
     try {
@@ -373,15 +368,13 @@ fi
       ['cc-safety-net@cc-marketplace', 'safety-net@cc-marketplace'],
       { enableByDefault: true },
     );
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'claude'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin uninstall safety-net@cc-marketplace" ]; then
-  echo "Plugin \\"safety-net@cc-marketplace\\" not found in installed plugins" >&2
-  exit 1
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'claude',
+      `if (commandLine === 'plugin uninstall safety-net@cc-marketplace') {
+  console.error('Plugin "safety-net@cc-marketplace" not found in installed plugins');
+  process.exit(1);
+}`,
     );
 
     try {
@@ -403,18 +396,17 @@ fi
 
   test('detects a Codex integration whose plugin list is slower than the version probe timeout', async () => {
     const fake = makeFakeBinHome('safety-net-update-slow-codex', ['codex']);
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'codex'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  if [ ! -f "$HOME/.codex-slept" ]; then
-    touch "$HOME/.codex-slept"
-    sleep 6
-  fi
-  printf 'safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled\n'
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'codex',
+      `if (commandLine === 'plugin list') {
+  const sleptPath = join(process.env.HOME ?? '', '.codex-slept');
+  if (!existsSync(sleptPath)) {
+    writeFileSync(sleptPath, '');
+    await Bun.sleep(6000);
+  }
+  console.log('safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled');
+}`,
     );
 
     await expectCodexLegacyMigration(fake);
@@ -476,19 +468,17 @@ fi
     const binDir = writeFakeCommands(homeDir, {
       // Personal-scope plugin line, repositories preflight, and a clone that leaves the
       // throwaway checkout empty. No network and no real Amp repository is involved.
-      amp: [
-        'case "$1 $2" in',
-        '  "plugins list") printf \'\\342\\234\\223 cc-safety-net (User Plugins) active\\n\' ;;',
-        '  "plugins repositories") printf \'[{"scope":"user","exists":true,"viewerCanWrite":true,"cloneRef":"tester/-/plugins"}]\\n\' ;;',
-        'esac',
-      ].join('\n'),
+      amp: `if (args[0] === 'plugins' && args[1] === 'list') {
+  console.log('✓ cc-safety-net (User Plugins) active');
+}
+if (args[0] === 'plugins' && args[1] === 'repositories') {
+  console.log('[{"scope":"user","exists":true,"viewerCanWrite":true,"cloneRef":"tester/-/plugins"}]');
+}`,
       // Only `git status --porcelain` needs a real answer: the modified directory-plugin entry
       // means the artifact is staged, so `commitAndPush` proceeds to commit and push.
-      git: [
-        'case "$1 $2" in',
-        '  "status --porcelain") printf \'%s\\n\' "M  cc-safety-net/index.ts" ;;',
-        'esac',
-      ].join('\n'),
+      git: `if (commandLine === 'status --porcelain') {
+  console.log('M  cc-safety-net/index.ts');
+}`,
     });
 
     try {
@@ -515,23 +505,17 @@ fi
     writeClaudePluginRecords(fake.homeDir, ['cc-safety-net@cc-marketplace'], {
       enableByDefault: true,
     });
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'claude'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin marketplace update cc-marketplace" ]; then
-  exit 42
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'claude',
+      `if (commandLine === 'plugin marketplace update cc-marketplace') process.exit(42);`,
     );
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'codex'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'cc-safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled\n'
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'codex',
+      `if (commandLine === 'plugin list') {
+  console.log('cc-safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled');
+}`,
     );
 
     try {
@@ -555,34 +539,27 @@ fi
     });
     // Claude Code runs before Codex in canonical order, and here it only finishes once Codex
     // signals that it started, so this passes only when the two targets run concurrently.
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'claude'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin marketplace update cc-marketplace" ]; then
-  i=0
-  while [ $i -lt 50 ]; do
-    if [ -f "$HOME/.codex-running" ]; then
-      exit 0
-    fi
-    sleep 0.1
-    i=$((i + 1))
-  done
-  exit 42
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'claude',
+      `if (commandLine === 'plugin marketplace update cc-marketplace') {
+  const runningPath = join(process.env.HOME ?? '', '.codex-running');
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (existsSync(runningPath)) process.exit(0);
+    await Bun.sleep(100);
+  }
+  process.exit(42);
+}`,
     );
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'codex'),
-      `#!/usr/bin/env sh
-printf '%s\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'cc-safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled\n'
-fi
-if [ "$*" = "plugin marketplace upgrade cc-marketplace" ]; then
-  touch "$HOME/.codex-running"
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'codex',
+      `if (commandLine === 'plugin list') {
+  console.log('cc-safety-net@cc-marketplace https://github.com/kenryu42/cc-safety-net.git installed, enabled');
+}
+if (commandLine === 'plugin marketplace upgrade cc-marketplace') {
+  writeFileSync(join(process.env.HOME ?? '', '.codex-running'), '');
+}`,
     );
 
     try {

--- a/tests/integrations/hook-helpers.ts
+++ b/tests/integrations/hook-helpers.ts
@@ -383,13 +383,16 @@ export async function runCli(
     ...(env ?? {}),
   };
 
-  const proc = Bun.spawn(['bun', join(process.cwd(), 'src/cli/cc-safety-net.ts'), ...args], {
-    stdin: 'pipe',
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: mergedEnv,
-    cwd,
-  });
+  const proc = Bun.spawn(
+    [process.execPath, join(process.cwd(), 'src/cli/cc-safety-net.ts'), ...args],
+    {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: mergedEnv,
+      cwd,
+    },
+  );
   proc.stdin.write(input);
   proc.stdin.end();
   const stdoutPromise = new Response(proc.stdout).text();

--- a/tests/integrations/install/hook-install.test.ts
+++ b/tests/integrations/install/hook-install.test.ts
@@ -14,6 +14,7 @@ import {
   makeLoggedFakeCommandHome,
   writeAntigravityConfig,
   writeClaudePluginRecords,
+  writeLoggedFakeCommand,
 } from './install-test-helpers';
 
 const CURSOR_CANONICAL_ENTRY = {
@@ -110,7 +111,7 @@ function readCommandLog(logPath: string): string[] {
 }
 
 function normalizedCommandLog(logPath: string): string[] {
-  return readCommandLog(logPath).map((entry) => entry.replace(/^.*\/bin\//, ''));
+  return readCommandLog(logPath).map((entry) => entry.replace(/^.*[\\/]bin[\\/]/, ''));
 }
 
 function runNativeCli(
@@ -151,14 +152,10 @@ function codexPluginListOptions(pluginList: string, options: NativeActionOptions
     isolatedBin: true,
     ...options,
     setup: (fake: ReturnType<typeof makeFakeBinHome>) => {
-      writeFileSync(
-        join(fake.homeDir, 'bin', 'codex'),
-        `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf '%s\\n' '${pluginList}'
-fi
-`,
+      writeLoggedFakeCommand(
+        fake.homeDir,
+        'codex',
+        `if (commandLine === 'plugin list') console.log(${JSON.stringify(pluginList)});`,
       );
     },
   };
@@ -548,14 +545,12 @@ describe('install command', () => {
       {
         isolatedBin: true,
         setup: (fake) => {
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'copilot'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\\n  copilot-safety-net (v1.0.0)\\n'
-fi
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'copilot',
+            `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify('Installed plugins:\n  copilot-safety-net (v1.0.0)')});
+}`,
           );
         },
       },
@@ -577,17 +572,15 @@ fi
       {
         isolatedBin: true,
         setup: (fake) => {
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'copilot'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\\n  • safety-net@cc-marketplace (v1.0.6)\\n'
-fi
-if [ "$*" = "plugin marketplace list" ]; then
-  printf 'Registered marketplaces:\\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)\\n'
-fi
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'copilot',
+            `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify('Installed plugins:\n  • safety-net@cc-marketplace (v1.0.6)')});
+}
+if (commandLine === 'plugin marketplace list') {
+  console.log(${JSON.stringify('Registered marketplaces:\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)')});
+}`,
           );
         },
       },
@@ -608,14 +601,14 @@ fi
       {
         isolatedBin: true,
         setup: (fake) => {
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'copilot'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\\n  cc-safety-net@cc-marketplace (v1.0.0)\\n  copilot-safety-net (v1.0.0)\\n'
-fi
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'copilot',
+            `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify(
+    'Installed plugins:\n  cc-safety-net@cc-marketplace (v1.0.0)\n  copilot-safety-net (v1.0.0)',
+  )});
+}`,
           );
         },
       },
@@ -624,15 +617,13 @@ fi
 
   test('legacy uninstall failure does not fail the install', async () => {
     const fake = makeFakeBinHome('safety-net-legacy-uninstall-fail', ['claude']);
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'claude'),
-      `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin uninstall safety-net@cc-marketplace" ]; then
-  echo "uninstall failed" >&2
-  exit 42
-fi
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'claude',
+      `if (commandLine === 'plugin uninstall safety-net@cc-marketplace') {
+  console.error('uninstall failed');
+  process.exit(42);
+}`,
     );
     writeClaudePluginRecords(fake.homeDir, ['safety-net@cc-marketplace'], {
       enabled: { 'safety-net@cc-marketplace': true },
@@ -711,14 +702,12 @@ fi
       {
         isolatedBin: true,
         setup: (fake) => {
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'copilot'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin marketplace list" ]; then
-  printf 'Registered marketplaces:\\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)\\n'
-fi
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'copilot',
+            `if (commandLine === 'plugin marketplace list') {
+  console.log(${JSON.stringify('Registered marketplaces:\n  • cc-marketplace (GitHub: kenryu42/cc-marketplace)')});
+}`,
           );
         },
       },
@@ -738,14 +727,12 @@ fi
       {
         isolatedBin: true,
         setup: (fake) => {
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'copilot'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  printf 'Installed plugins:\\n  • cc-safety-net@cc-marketplace (v1.0.6)\\n'
-fi
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'copilot',
+            `if (commandLine === 'plugin list') {
+  console.log(${JSON.stringify('Installed plugins:\n  • cc-safety-net@cc-marketplace (v1.0.6)')});
+}`,
           );
         },
       },
@@ -884,14 +871,13 @@ fi
           // `opencode plugin` reifies the package into the cache, and the install now refuses to
           // report success without it, so the fake has to leave the same layout behind.
           const packageDir = join(cachePath, 'node_modules', 'cc-safety-net');
-          writeFileSync(
-            join(fake.homeDir, 'bin', 'opencode'),
-            `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-mkdir -p '${packageDir}'
-printf '%s' '{"main":"index.js"}' > '${packageDir}/package.json'
-printf '%s' 'export const CCSafetyNetPlugin = () => {};' > '${packageDir}/index.js'
-`,
+          writeLoggedFakeCommand(
+            fake.homeDir,
+            'opencode',
+            `const packageDir = ${JSON.stringify(packageDir)};
+mkdirSync(packageDir, { recursive: true });
+writeFileSync(join(packageDir, 'package.json'), '{"main":"index.js"}');
+writeFileSync(join(packageDir, 'index.js'), 'export const CCSafetyNetPlugin = () => {};');`,
           );
         },
         assert: (fake) => {
@@ -923,17 +909,13 @@ printf '%s' 'export const CCSafetyNetPlugin = () => {};' > '${packageDir}/index.
 
   test('native installer fails fast and reports command output', async () => {
     const fake = makeFakeBinHome('safety-net-native-install-fail', ['codex']);
-    writeFileSync(
-      join(fake.homeDir, 'bin', 'codex'),
-      `#!/usr/bin/env sh
-printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"
-if [ "$*" = "plugin list" ]; then
-  exit 0
-fi
-echo "native stdout"
-echo "native stderr" >&2
-exit 42
-`,
+    writeLoggedFakeCommand(
+      fake.homeDir,
+      'codex',
+      `if (commandLine === 'plugin list') process.exit(0);
+console.log('native stdout');
+console.error('native stderr');
+process.exit(42);`,
     );
 
     try {

--- a/tests/integrations/install/install-test-helpers.test.ts
+++ b/tests/integrations/install/install-test-helpers.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test';
 import { readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { runNativeCommand } from '@/integrations/install/native';
 import { withEnv } from '../../helpers';
 import { makeLoggedFakeCommandHome } from './install-test-helpers';
@@ -15,13 +14,15 @@ test('[windows] discovers a fake command through PATH and logs its arguments', a
         PATHEXT: '.CMD',
         CC_SAFETY_NET_TEST_COMMAND_LOG: fake.logPath,
       },
-      () => runNativeCommand(['portable-fake', 'arg with space', '--flag']),
+      () => runNativeCommand(['portable-fake', 'plugin', 'list']),
     );
 
     expect(output).toBe('');
-    expect(readFileSync(fake.logPath, 'utf-8')).toBe(
-      `${join(fake.binDir, 'portable-fake')} arg with space --flag\n`,
-    );
+    expect(
+      readFileSync(fake.logPath, 'utf-8')
+        .trim()
+        .replace(/^.*[\\/]bin[\\/]/i, ''),
+    ).toBe('portable-fake plugin list');
   } finally {
     rmSync(fake.homeDir, { recursive: true, force: true });
   }

--- a/tests/integrations/install/install-test-helpers.test.ts
+++ b/tests/integrations/install/install-test-helpers.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'bun:test';
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { runNativeCommand } from '@/integrations/install/native';
+import { withEnv } from '../../helpers';
+import { makeLoggedFakeCommandHome } from './install-test-helpers';
+
+test('[windows] discovers a fake command through PATH and logs its arguments', async () => {
+  const fake = makeLoggedFakeCommandHome('safety-net-portable-fake-command', ['portable-fake']);
+
+  try {
+    const output = await withEnv(
+      {
+        PATH: fake.binDir,
+        PATHEXT: '.CMD',
+        CC_SAFETY_NET_TEST_COMMAND_LOG: fake.logPath,
+      },
+      () => runNativeCommand(['portable-fake', 'arg with space', '--flag']),
+    );
+
+    expect(output).toBe('');
+    expect(readFileSync(fake.logPath, 'utf-8')).toBe(
+      `${join(fake.binDir, 'portable-fake')} arg with space --flag\n`,
+    );
+  } finally {
+    rmSync(fake.homeDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integrations/install/install-test-helpers.ts
+++ b/tests/integrations/install/install-test-helpers.ts
@@ -41,11 +41,43 @@ export function writeFakeCommands(homeDir: string, bodies: Readonly<Record<strin
   const binDir = join(homeDir, 'bin');
   mkdirSync(binDir, { recursive: true });
   Object.entries(bodies).forEach(([command, body]) => {
-    const path = join(binDir, command);
-    writeFileSync(path, `#!/usr/bin/env sh\n${body}\n`);
-    chmodSync(path, 0o755);
+    const commandPath = join(binDir, command);
+    const bodyPath = `${commandPath}.ts`;
+    writeFileSync(
+      bodyPath,
+      `import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const commandLine = args.join(' ');
+const commandPath = join(import.meta.dir, ${JSON.stringify(command)});
+
+${body}
+`,
+    );
+    writeFileSync(
+      commandPath,
+      `#!/bin/sh
+exec '${process.execPath.replaceAll("'", "'\"'\"'")}' '${bodyPath.replaceAll("'", "'\"'\"'")}' "$@"
+`,
+    );
+    chmodSync(commandPath, 0o755);
+    writeFileSync(
+      `${commandPath}.cmd`,
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}.ts" %*\r\n`,
+    );
   });
   return binDir;
+}
+
+export function writeLoggedFakeCommand(homeDir: string, command: string, body = '') {
+  return writeFakeCommands(homeDir, {
+    [command]: `appendFileSync(
+  process.env.CC_SAFETY_NET_TEST_COMMAND_LOG ?? '',
+  commandPath + ' ' + commandLine + '\\n',
+);
+${body}`,
+  });
 }
 
 export function writeLoggedFakeCommands(homeDir: string, commands: readonly string[]) {
@@ -54,7 +86,10 @@ export function writeLoggedFakeCommands(homeDir: string, commands: readonly stri
     Object.fromEntries(
       commands.map((command) => [
         command,
-        `printf '%s\\n' "$0 $*" >> "$CC_SAFETY_NET_TEST_COMMAND_LOG"`,
+        `appendFileSync(
+  process.env.CC_SAFETY_NET_TEST_COMMAND_LOG ?? '',
+  commandPath + ' ' + commandLine + '\\n',
+);`,
       ]),
     ),
   );


### PR DESCRIPTION
## Summary

- execute fake command behavior as portable Bun scripts
- generate an executable POSIX launcher and a `.cmd` launcher for each fake command
- retain argument and environment-based command logging across path separators
- use `process.execPath` when test subprocesses replace `PATH`
- add a `[windows]` test that executes a fake through `PATH` and verifies its argument log

## Root cause

`writeFakeCommands` wrote extensionless `#!/usr/bin/env sh` files and relied on `chmod`. Native Windows command lookup cannot execute those files, so install and update tests failed before reaching the behavior they intended to exercise. Custom fixture overrides in the callers had the same shell-only assumption.

The fixture now keeps behavior in Bun-executed TypeScript and exposes it through the launcher each platform expects. Product code and install behavior are unchanged.

## Verification

- `bun run check` (5,093 passed, 35 skipped, 0 failed; coverage verified)
- `bun test tests/integrations/install/install-test-helpers.test.ts tests/cli/install/orchestration.test.ts tests/cli/install/update.test.ts tests/integrations/install/hook-install.test.ts` (127 passed, 0 failed)
- [native Windows Tests](https://github.com/kenryu42/cc-safety-net/actions/runs/33867321683): 32 passed, 16 skipped, 0 failed, including PATH/PATHEXT fake-command discovery and logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved installation and integration test coverage across Unix and Windows environments.
  * Added validation for command discovery when Windows `PATHEXT` settings are present.
  * Standardized simulated command behavior and invocation logging across installation scenarios.
  * Improved test reliability by running subprocess checks with the same runtime as the test suite.
  * Added cross-platform handling for command paths, arguments, and executable wrappers.
  * Expanded coverage for CLI integrations, installation failures, concurrency, and plugin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->