### PR TITLE
ci: enforce full checks on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,32 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  full-check-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.4.0
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Check source
+        run: bun run check:ci
+        env:
+          CC_SAFETY_NET_E2E_ARTIFACTS: ${{ runner.temp }}/cc-safety-net-e2e
+      - name: Rebuild owned artifacts
+        run: bun run build
+      - name: Reject stale generated artifacts
+        run: git diff --exit-code -- dist assets/cc-safety-net.schema.json THIRD_PARTY_LICENSES.txt
+      - name: Upload E2E failure evidence
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: e2e-failure-evidence-macos
+          path: ${{ runner.temp }}/cc-safety-net-e2e
+          if-no-files-found: ignore
+          retention-days: 7
+
   packed-runtime:
     needs: full-check
     strategy:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -26,14 +26,9 @@ jobs:
           bun-version: 1.4.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - run: bun run lint:ci
-      - run: bun run typecheck
-      - run: bun run knip
-      - run: bun run check-duplicates
-      - name: Run native Windows tests
-        run: bun test tests --test-name-pattern '\[windows\]'
+      - name: Check source
+        run: bun run check:ci
         env:
-          AGENT: "1"
           CC_SAFETY_NET_E2E_ARTIFACTS: ${{ runner.temp }}/cc-safety-net-e2e
       - run: bun run build
       - run: git diff --exit-code -- dist assets/cc-safety-net.schema.json THIRD_PARTY_LICENSES.txt

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -150,9 +150,13 @@ describe('status command', () => {
     const result = await runStatus();
 
     expect(factValue(result.output, 'Project')).not.toBe('');
-    expect(join(await realpath(project), '.cc-safety-net', 'policy.json')).toStartWith(
-      factValue(result.output, 'Project').slice(0, -1),
-    );
+    expect(
+      [project, await realpath(project)].some((candidate) =>
+        join(candidate, '.cc-safety-net', 'policy.json').startsWith(
+          factValue(result.output, 'Project').slice(0, -1),
+        ),
+      ),
+    ).toBeTrue();
     expect(result.output).toMatch(/^ {2}Level\s+standard$/m);
     expect(result.output).toMatch(/^ {2}Project policy$/m);
     expect(result.output).toMatch(/^ {4}project policy lowers level: strict -> standard$/m);

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { printStatus } from '@/cli/status';
@@ -150,7 +150,7 @@ describe('status command', () => {
     const result = await runStatus();
 
     expect(factValue(result.output, 'Project')).not.toBe('');
-    expect(join(project, '.cc-safety-net', 'policy.json')).toStartWith(
+    expect(join(await realpath(project), '.cc-safety-net', 'policy.json')).toStartWith(
       factValue(result.output, 'Project').slice(0, -1),
     );
     expect(result.output).toMatch(/^ {2}Level\s+standard$/m);

--- a/tests/integrations/pi/tool-call.test.ts
+++ b/tests/integrations/pi/tool-call.test.ts
@@ -457,7 +457,7 @@ describe('Pi tool_call event', () => {
             segment: '.env',
             reason: 'Access to a sensitive path is not allowed.',
             ruleId: 'secret.basename.env',
-            cwd: dir,
+            cwd: realpathSync(dir),
           }),
         );
       });

--- a/tests/scripts/package-git-head.test.ts
+++ b/tests/scripts/package-git-head.test.ts
@@ -32,5 +32,5 @@ describe('release package identity', () => {
       expect(packedNotices.exitCode).toBe(0);
       expect(packedNotices.stdout.toString()).toBe(renderThirdPartyLicenses());
     });
-  }, 20_000);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- Keep the existing Linux `full-check` contract intact.
- Make `Windows Tests / test-windows` run the complete CI-safe source contract with `bun run check:ci`, while retaining its native PowerShell command smoke, build, generated-artifact diff, and Windows-specific E2E evidence artifact.
- Add `CI / full-check-macos` on `macos-latest` with Bun 1.4.0, the complete `bun run check:ci`, build/generated-artifact consistency, and a macOS-specific E2E evidence artifact.
- Normalize the platform-sensitive test expectations exposed by native macOS and Windows, and give the observed Windows `npm pack` integration test a 30-second budget.

## Full source/test contract

| Host | Stable PR check | Enforced contract | Current PR evidence |
| --- | --- | --- | --- |
| Linux | `CI / full-check` | `bun run check:ci`; existing audit, E2E stability, build/generated diff, package-surface verification, and Codecov remain unchanged | [5,099 pass / 36 skip / 0 fail](https://github.com/kenryu42/cc-safety-net/actions/runs/33890565591/job/101080917409) |
| Windows | `Windows Tests / test-windows` | `bun run check:ci`; build/generated diff; native PowerShell command smoke; Windows E2E failure evidence | [5,111 pass / 24 skip / 0 fail](https://github.com/kenryu42/cc-safety-net/actions/runs/33890565703/job/101080917787) |
| macOS | `CI / full-check-macos` | `bun run check:ci`; build/generated diff; macOS E2E failure evidence | [5,100 pass / 35 skip / 0 fail](https://github.com/kenryu42/cc-safety-net/actions/runs/33890565591/job/101080917648) |

`[windows]`-named tests remain useful additive native scenarios inside the full Windows suite; they no longer replace the portable source/test contract through an exclusive name filter.

The packed-runtime matrix is unchanged: Node 18/20/22/24 on Ubuntu and Node 24 on Windows/macOS, with `fail-fast: false`.

## Portability findings resolved

The first native macOS full run exposed `/var` versus `/private/var` canonical-path differences in two expectations. The follow-up Windows run showed that `realpath` can instead yield an equivalent 8.3 temp path while the CLI reports the long path. The assertions now accept the lexical or canonical project prefix as appropriate, and the Pi audit expectation uses the canonical fixture path. The same Windows run showed a successful `npm pack` crossing the former 20-second test budget under full-suite load, so that integration test now allows 30 seconds.

## Validation

- Local Bun 1.4.0: `bun run check` — 5,099 pass / 36 skip / 0 fail; coverage 97.38% lines / 97.84% functions.
- Native Linux, Windows, and macOS full checks linked in the contract table are green on head `ad27ca96eed5500c16f7884f129bf96bc4bf2bda`.
- Both pinned repository `actionlint` checks pass.
- All six unchanged packed-runtime jobs pass.
- Codecov project/patch, CodeRabbit, Greptile, and Pullfrog are green; current-head bot reviews have no actionable findings.
